### PR TITLE
undergarden spirit harvesting (hope i did this right)

### DIFF
--- a/src/main/resources/data/malum/malum_spirit_data/brute.json
+++ b/src/main/resources/data/malum/malum_spirit_data/brute.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "undergarden:brute",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/dweller.json
+++ b/src/main/resources/data/malum/malum_spirit_data/dweller.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "undergarden:dweller",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/forgotten_guardian.json
+++ b/src/main/resources/data/malum/malum_spirit_data/forgotten_guardian.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "undergarden:forgotten_guardian",
+  "primary_type": "eldrich",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 3
+    },
+    {
+      "spirit": "eldrich",
+      "count": 5
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/gloomper.json
+++ b/src/main/resources/data/malum/malum_spirit_data/gloomper.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "undergarden:gloomper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/gwib.json
+++ b/src/main/resources/data/malum/malum_spirit_data/gwib.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "undergarden:gwib",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/gwibling.json
+++ b/src/main/resources/data/malum/malum_spirit_data/gwibling.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "undergarden:gwibling",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/mog.json
+++ b/src/main/resources/data/malum/malum_spirit_data/mog.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "undergarden:mog",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 3
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/muncher.json
+++ b/src/main/resources/data/malum/malum_spirit_data/muncher.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "undergarden:muncher",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/nargoyle.json
+++ b/src/main/resources/data/malum/malum_spirit_data/nargoyle.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "undergarden:nargoyle",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/scintling.json
+++ b/src/main/resources/data/malum/malum_spirit_data/scintling.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "undergarden:scintling",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/sploogie.json
+++ b/src/main/resources/data/malum/malum_spirit_data/sploogie.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "undergarden:sploogie",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/stoneborn.json
+++ b/src/main/resources/data/malum/malum_spirit_data/stoneborn.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "undergarden:stoneborn",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 2
+    }
+    {
+      "spirit": "earthen",
+      "count": 3
+    }
+  ]
+}


### PR DESCRIPTION
speedily and spimpily made jsons that allow you to harvest the spirits of the undergarden's mobs.
omitted mobs: rotspawn (no idea if they even have souls), masticator (it's not even encounterable yet), and the minion (it's a golem)
lemme know if this pr causes issues all i did was make jsons
no idea if this will even work with undergarden 1.18 as that isn't out yet lmao