### PR TITLE
more spirit harvesting

### DIFF
--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_creepie.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_creepie.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "savageandravage:creepie",
+  "primary_type": "infernal",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_duck.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_duck.json
@@ -1,5 +1,6 @@
 {
-  "registry_name": "environmental:yak",
+  "registry_name": "environmental:duck",
+  "primary_type": "earthen",
   "spirits": [
     {
       "spirit": "sacred",

--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_goose.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_goose.json
@@ -1,5 +1,6 @@
 {
-  "registry_name": "environmental:duck",
+  "registry_name": "upgrade_aquatic:goose",
+  "primary_type": "earthen",
   "spirits": [
     {
       "spirit": "sacred",

--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_iceologer.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_iceologer.json
@@ -1,5 +1,6 @@
 {
-  "registry_name": "eidolon:necromancer",
+  "registry_name": "savageandravage:iceologer",
+  "primary_type": "arcane",
   "spirits": [
     {
       "spirit": "wicked",

--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_koi.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_koi.json
@@ -1,5 +1,6 @@
 {
   "registry_name": "environmental:koi",
+  "primary_type": "aqueous",
   "spirits": [
     {
       "spirit": "aqueous",

--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_lionfish.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_lionfish.json
@@ -1,5 +1,6 @@
 {
   "registry_name": "upgrade_aquatic:lionfish",
+  "primary_type": "aqueous",
   "spirits": [
     {
       "spirit": "wicked",

--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_moobloom.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_moobloom.json
@@ -1,5 +1,6 @@
 {
   "registry_name": "buzzier_bees:moobloom",
+  "primary_type": "earthen",
   "spirits": [
     {
       "spirit": "sacred",

--- a/src/main/resources/data/malum/malum_spirit_data/abnormals_yak.json
+++ b/src/main/resources/data/malum/malum_spirit_data/abnormals_yak.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "environmental:yak",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/coconut_crab.json
+++ b/src/main/resources/data/malum/malum_spirit_data/coconut_crab.json
@@ -1,5 +1,5 @@
 {
-  "registry_name": "upgrade_aquatic:glow_squid",
+  "registry_name": "ecologics:coconut_crab",
   "primary_type": "aqueous",
   "spirits": [
     {

--- a/src/main/resources/data/malum/malum_spirit_data/eidolon_necromancer.json
+++ b/src/main/resources/data/malum/malum_spirit_data/eidolon_necromancer.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "eidolon:necromancer",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 2
+    },
+    {
+      "spirit": "eldritch",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/eidolon_raven.json
+++ b/src/main/resources/data/malum/malum_spirit_data/eidolon_raven.json
@@ -1,12 +1,13 @@
 {
-  "registry_name": "savageandravage:creepie",
+  "registry_name": "eidolon:raven",
+  "primary_type": "aerial",
   "spirits": [
     {
       "spirit": "wicked",
       "count": 1
     },
     {
-      "spirit": "infernal",
+      "spirit": "aerial",
       "count": 1
     }
   ]

--- a/src/main/resources/data/malum/malum_spirit_data/eidolon_wraith.json
+++ b/src/main/resources/data/malum/malum_spirit_data/eidolon_wraith.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "eidolon:wraith",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/enchanterwithmob.json
+++ b/src/main/resources/data/malum/malum_spirit_data/enchanterwithmob.json
@@ -1,5 +1,6 @@
 {
-  "registry_name": "savageandravage:iceologer",
+  "registry_name": "enchantwithmob:enchanter",
+  "primary_type": "arcane",
   "spirits": [
     {
       "spirit": "wicked",
@@ -8,10 +9,6 @@
     {
       "spirit": "arcane",
       "count": 2
-    },
-    {
-      "spirit": "eldritch",
-      "count": 1
     }
   ]
 }

--- a/src/main/resources/data/malum/malum_spirit_data/forgotten.json
+++ b/src/main/resources/data/malum/malum_spirit_data/forgotten.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "quark:forgotten",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 2
+    },
+    {
+      "spirit": "arcane",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/foxhound.json
+++ b/src/main/resources/data/malum/malum_spirit_data/foxhound.json
@@ -1,0 +1,17 @@
+{
+  "registry_name": "quark:foxhound",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/frog.json
+++ b/src/main/resources/data/malum/malum_spirit_data/frog.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "quark:frog",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/goblin_trader.json
+++ b/src/main/resources/data/malum/malum_spirit_data/goblin_trader.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "goblintraders:goblin_trader",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/hunterillager.json
+++ b/src/main/resources/data/malum/malum_spirit_data/hunterillager.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "hunterillager:hunterillager",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/moonflower_creepie.json
+++ b/src/main/resources/data/malum/malum_spirit_data/moonflower_creepie.json
@@ -1,0 +1,13 @@
+{
+  "registry_name": "tolerable_creepers:creepie",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/passerine.json
+++ b/src/main/resources/data/malum/malum_spirit_data/passerine.json
@@ -1,8 +1,9 @@
 {
-  "registry_name": "eidolon:raven",
+  "registry_name": "habitat:passerine",
+  "primary_type": "aerial",
   "spirits": [
     {
-      "spirit": "wicked",
+      "spirit": "sacred",
       "count": 1
     },
     {

--- a/src/main/resources/data/malum/malum_spirit_data/pooka.json
+++ b/src/main/resources/data/malum/malum_spirit_data/pooka.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "habitat:pooka",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 2
+    },
+    {
+      "spirit": "aerial",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/quark_crab.json
+++ b/src/main/resources/data/malum/malum_spirit_data/quark_crab.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "quark:crab",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/quark_wraith.json
+++ b/src/main/resources/data/malum/malum_spirit_data/quark_wraith.json
@@ -1,5 +1,6 @@
 {
-  "registry_name": "eidolon:wraith",
+  "registry_name": "quark:wraith",
+  "primary_type": "arcane",
   "spirits": [
     {
       "spirit": "arcane",

--- a/src/main/resources/data/malum/malum_spirit_data/red_merchant.json
+++ b/src/main/resources/data/malum/malum_spirit_data/red_merchant.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "supplementaries:red_merchant",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 2
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/shiba.json
+++ b/src/main/resources/data/malum/malum_spirit_data/shiba.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "quark:shiba",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/snow_pig.json
+++ b/src/main/resources/data/malum/malum_spirit_data/snow_pig.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "snowpig:snow_pig",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/snuffle.json
+++ b/src/main/resources/data/malum/malum_spirit_data/snuffle.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "snuffles:snuffle",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/stoneling.json
+++ b/src/main/resources/data/malum/malum_spirit_data/stoneling.json
@@ -1,8 +1,9 @@
 {
-  "registry_name": "upgrade_aquatic:goose",
+  "registry_name": "quark:stoneling",
+  "primary_type": "earthen",
   "spirits": [
     {
-      "spirit": "sacred",
+      "spirit": "arcane",
       "count": 1
     },
     {

--- a/src/main/resources/data/malum/malum_spirit_data/toretoise.json
+++ b/src/main/resources/data/malum/malum_spirit_data/toretoise.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "quark:toretoise",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/malum_spirit_data/vein_goblin_trader.json
+++ b/src/main/resources/data/malum/malum_spirit_data/vein_goblin_trader.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "goblintraders:vein_goblin_trader",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 2
+    },
+    {
+      "spirit": "infernal",
+      "count": 1
+    }
+  ]
+}


### PR DESCRIPTION
mods this round:
quark: all mobs, done
eilodon: changed names of files, renamed files are 2.0 format BUT unrenamed files did not get format update
abnormals: ditto with eidolon
tolerable creepers: creepie (may need namespace changed if i got it wrong)
enchant with mob: done
hunter illager: done
habitat: all mobs, done
snuffles: done
snow pig: done
ecologics: done
goblin traders: all gobs, done
supplementaries: done
PLEASE review these, the new/renamed files are the only ones in the 2.0 format (along with the UG ones), as to not conflict with the upcoming changes from another branch