### PR TITLE
Add Botania spirit data and fix typo

### DIFF
--- a/src/main/resources/data/malum/spirit_data/botania/gaia_guardian.json
+++ b/src/main/resources/data/malum/spirit_data/botania/gaia_guardian.json
@@ -1,0 +1,22 @@
+{
+  "registry_name": "botania:doppleganger",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 3
+    },
+    {
+      "spirit": "eldritch",
+      "count": 3
+    },
+    {
+      "spirit": "wicked",
+      "count": 2
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/botania/pink_wither.json
+++ b/src/main/resources/data/malum/spirit_data/botania/pink_wither.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "minecraft:wither",
+  "primary_type": "infernal",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 3
+    },
+    {
+      "spirit": "arcane",
+      "count": 3
+    },
+    {
+      "spirit": "infernal",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/undergarden_forgotten_guardian.json
+++ b/src/main/resources/data/malum/spirit_data/undergarden_forgotten_guardian.json
@@ -1,13 +1,13 @@
 {
   "registry_name": "undergarden:forgotten_guardian",
-  "primary_type": "eldrich",
+  "primary_type": "eldritch",
   "spirits": [
     {
       "spirit": "earthen",
       "count": 3
     },
     {
-      "spirit": "eldrich",
+      "spirit": "eldritch",
       "count": 5
     }
   ]


### PR DESCRIPTION
I somehow thought it would be more, but it turns out we only have 3 entities that count as "living", and pixies really shouldn't have any drops as they are far too farmable.

Also fixes a single typo that I noticed while looking through the files. 