### PR TITLE
Undergarden Tool Spirit Repairing

### DIFF
--- a/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/cloggrum.json
+++ b/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/cloggrum.json
@@ -1,0 +1,22 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "undergarden"
+    }
+  ],
+  "type": "malum:spirit_repair",
+  "inputLookup": "cloggrum_",
+  "durabilityPercentage": 0.5,
+  "inputs": [],
+  "repairMaterial": {
+    "item": "undergarden:cloggrum_ingot",
+    "count": 2
+  },
+  "spirits": [
+    {
+      "type": "earthen",
+      "count": 12
+    }
+  ]
+}

--- a/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/forgotten.json
+++ b/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/forgotten.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "undergarden"
+    }
+  ],
+  "type": "malum:spirit_repair",
+  "inputLookup": "undergarden:forgotten_",
+  "durabilityPercentage": 0.75,
+  "inputs": [],
+  "repairMaterial": {
+    "item": "undergarden:forgotten_ingot",
+    "count": 1
+  },
+  "spirits": [
+    {
+      "type": "earthen",
+      "count": 20
+    },
+    {
+      "type": "arcane",
+      "count": 12
+    },
+    {
+      "type": "eldritch"
+    }
+  ]
+}

--- a/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/froststeel.json
+++ b/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/froststeel.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "undergarden"
+    }
+  ],
+  "type": "malum:spirit_repair",
+  "inputLookup": "froststeel_",
+  "durabilityPercentage": 0.5,
+  "inputs": [],
+  "repairMaterial": {
+    "item": "undergarden:froststeel_ingot",
+    "count": 2
+  },
+  "spirits": [
+    {
+      "type": "aqueous",
+      "count": 8
+    },
+    {
+      "type": "arcane",
+      "count": 4
+    }
+  ]
+}

--- a/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/slingshot.json
+++ b/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/slingshot.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "undergarden"
+    }
+  ],
+  "type": "malum:spirit_repair",
+  "inputLookup": "none",
+  "durabilityPercentage": 0.5,
+  "inputs": [
+    "undergarden:slingshot"
+	],
+  "repairMaterial": {
+    "item": "undergarden:twistytwig",
+    "count": 1
+  },
+  "spirits": [
+    {
+      "type": "earthen",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/utherium.json
+++ b/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/undergarden/utherium.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "undergarden"
+    }
+  ],
+  "type": "malum:spirit_repair",
+  "inputLookup": "utherium_",
+  "durabilityPercentage": 0.5,
+  "inputs": [],
+  "repairMaterial": {
+    "item": "undergarden:utherium_crystal",
+    "count": 2
+  },
+  "spirits": [
+    {
+      "type": "arcane",
+      "count": 12
+    },
+    {
+      "type": "infernal",
+      "count": 12
+    }
+  ]
+}


### PR DESCRIPTION
Adds spirit repair recipes for the Undergarden's tools, both the tiered stuff and the slingshot.