### PR TITLE
Mod Compat

### DIFF
--- a/src/main/resources/data/malum/spirit_data/entity/betterend/cubozoa.json
+++ b/src/main/resources/data/malum/spirit_data/entity/betterend/cubozoa.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "betterend:cobozoa",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/betterend/dragonfly.json
+++ b/src/main/resources/data/malum/spirit_data/entity/betterend/dragonfly.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "betterend:dragonfly",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/betterend/end_fish.json
+++ b/src/main/resources/data/malum/spirit_data/entity/betterend/end_fish.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "betterend:end_fish",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "eldritch",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/betterend/end_slime.json
+++ b/src/main/resources/data/malum/spirit_data/entity/betterend/end_slime.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "betterend:end_slime",
+  "primary_type": "eldritch",
+  "spirits": [
+    {
+      "spirit": "eldritch",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/betterend/shadow_walker.json
+++ b/src/main/resources/data/malum/spirit_data/entity/betterend/shadow_walker.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "betterend:shadow_walker",
+  "primary_type": "eldritch",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "eldritch",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/betterend/silk_moth.json
+++ b/src/main/resources/data/malum/spirit_data/entity/betterend/silk_moth.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "betterend:silk_moth",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/gauntlet.json
+++ b/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/gauntlet.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "bosses_of_mass_destruction:gauntlet",
+  "primary_type": "infernal",
+  "spirits": [
+    {
+      "spirit": "eldritch",
+      "count": 3
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 5
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/lich.json
+++ b/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/lich.json
@@ -13,10 +13,10 @@
     {
       "spirit": "aerial",
       "count": 1
-    }
+    },
     {
       "spirit": "eldritch",
       "count": 2
-    },
+    }
   ]
 }

--- a/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/lich.json
+++ b/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/lich.json
@@ -1,0 +1,22 @@
+{
+  "registry_name": "bosses_of_mass_destruction:lich",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 6
+    },
+    {
+      "spirit": "arcane",
+      "count": 5
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+    {
+      "spirit": "eldritch",
+      "count": 2
+    },
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/obsidilith.json
+++ b/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/obsidilith.json
@@ -1,5 +1,5 @@
 {
-  "registry_name": "bosses_of_mass_destruction:gauntlet",
+  "registry_name": "bosses_of_mass_destruction:obsidilith",
   "primary_type": "earthen",
   "spirits": [
     {
@@ -13,10 +13,10 @@
     {
       "spirit": "earthen",
       "count": 7
-    }
+    },
     {
       "spirit": "sacred",
       "count": 1
-    },
+    }
   ]
 }

--- a/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/obsidilith.json
+++ b/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/obsidilith.json
@@ -1,0 +1,22 @@
+{
+  "registry_name": "bosses_of_mass_destruction:gauntlet",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "eldritch",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 3
+    },
+    {
+      "spirit": "earthen",
+      "count": 7
+    }
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/void_blossom.json
+++ b/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/void_blossom.json
@@ -1,0 +1,22 @@
+{
+  "registry_name": "bosses_of_mass_destruction:void_blossom",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 4
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 5
+    }
+    {
+      "spirit": "sacred",
+      "count": 2
+    },
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/void_blossom.json
+++ b/src/main/resources/data/malum/spirit_data/entity/bosses_of_mass_destruction/void_blossom.json
@@ -13,10 +13,10 @@
     {
       "spirit": "earthen",
       "count": 5
-    }
+    },
     {
       "spirit": "sacred",
       "count": 2
-    },
+    }
   ]
 }

--- a/src/main/resources/data/malum/spirit_data/entity/duckling/duck.json
+++ b/src/main/resources/data/malum/spirit_data/entity/duckling/duck.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "duckling:duck",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/duckling/quackling.json
+++ b/src/main/resources/data/malum/spirit_data/entity/duckling/quackling.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "duckling:quackling",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 2
+    },
+    {
+      "spirit": "aerial",
+      "count": 2
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/earth/carbonarea.json
+++ b/src/main/resources/data/malum/spirit_data/entity/earth/carbonarea.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "earth:carbonarea",
+  "primary_type": "infernal",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/earth/carboranea.json
+++ b/src/main/resources/data/malum/spirit_data/entity/earth/carboranea.json
@@ -1,5 +1,5 @@
 {
-  "registry_name": "earth:carbonarea",
+  "registry_name": "earth:carbonorea",
   "primary_type": "infernal",
   "spirits": [
     {

--- a/src/main/resources/data/malum/spirit_data/entity/earth/carboranea.json
+++ b/src/main/resources/data/malum/spirit_data/entity/earth/carboranea.json
@@ -1,5 +1,5 @@
 {
-  "registry_name": "earth:carbonorea",
+  "registry_name": "earth:carboranea",
   "primary_type": "infernal",
   "spirits": [
     {

--- a/src/main/resources/data/malum/spirit_data/entity/earth/pertilyo.json
+++ b/src/main/resources/data/malum/spirit_data/entity/earth/pertilyo.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "earth:pertilyo",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 2
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/earth/rubro.json
+++ b/src/main/resources/data/malum/spirit_data/entity/earth/rubro.json
@@ -1,0 +1,11 @@
+
+{
+  "registry_name": "earth:rubro",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 4
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/copper_golem.json
+++ b/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/copper_golem.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "friendsandfoes:copper_golem",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/glare.json
+++ b/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/glare.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "friendsandfoes:glare",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 2
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/iceologer.json
+++ b/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/iceologer.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "friendsandfoes:iceologer",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/mauler.json
+++ b/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/mauler.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "friendsandfoes:mauler",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 4
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/moobloom.json
+++ b/src/main/resources/data/malum/spirit_data/entity/friendsandfoes/moobloom.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "friendsandfoes:moobloom",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/guardvillagers/guard.json
+++ b/src/main/resources/data/malum/spirit_data/entity/guardvillagers/guard.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "guardvillagers:guard",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/magicfungi/morbus_mooshroom.json
+++ b/src/main/resources/data/malum/spirit_data/entity/magicfungi/morbus_mooshroom.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "magicfungi:morbus_mooshroom",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 3
+    },
+    {
+      "spirit": "eldritch",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/progressivebosses/larva.json
+++ b/src/main/resources/data/malum/spirit_data/entity/progressivebosses/larva.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "progressivebosses:larva",
+  "primary_type": "eldritch",
+  "spirits": [
+    {
+      "spirit": "eldritch",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/progressivebosses/wither_minion.json
+++ b/src/main/resources/data/malum/spirit_data/entity/progressivebosses/wither_minion.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "progressivebosses:wither_minion",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/strawgolem/strawgolem.json
+++ b/src/main/resources/data/malum/spirit_data/entity/strawgolem/strawgolem.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "strawgolem:strawgolem",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/strawgolem/strawngolem.json
+++ b/src/main/resources/data/malum/spirit_data/entity/strawgolem/strawngolem.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "strawgolem:strawnggolem",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 4
+    },
+    {
+      "spirit": "earthen",
+      "count": 8
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds compatibility between Malum and MagicFungi, GuardVillagers, Earthbounds, Friends and Foes, Ducklings, BetterEnd, Straw Golem, Bosses of Mass Destruction

This is primarily targeted at the Quilt version of the mod but some of these are cross-loader like Friends and Foes and Better End.

Adds mobs from the above mods to have spirit drops.