### PR TITLE
Terrasteel armor put in Inputs array

### DIFF
--- a/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/botania/terrasteel.json
+++ b/src/main/resources/data/malum/recipes/malum/spirit_crucible/repair/botania/terrasteel.json
@@ -6,9 +6,13 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "inputLookup": "terra",
+  "inputLookup": "terra_",
   "durabilityPercentage": 1,
   "inputs": [
+    "botania:terrasteel_helmet",
+    "botania:terrasteel_chestplate",
+    "botania:terrasteel_leggings",
+    "botania:terrasteel_boots"
   ],
   "repairMaterial": {
     "item": "botania:terrasteel_ingot",


### PR DESCRIPTION
I put the registry names of all Terrasteel armor pieces in the Inputs array.

There's need to add the weapons since they are already checked by the inputLookup.