### PR TITLE
1.18.2 additional spirits

### DIFF
--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/arapaima.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/arapaima.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:arapaima",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/arrau_turtle.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/arrau_turtle.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "aquaculture:arrau_turtle",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/atlantic_cod.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/atlantic_cod.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:atlantic_cod",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/atlantic_halibut.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/atlantic_halibut.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:atlantic_halibut",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/atlantic_herring.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/atlantic_herring.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "aquaculture:atlantic_herring",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/bayad.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/bayad.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:bayad",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/blackfish.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/blackfish.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:blackfish",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/bluegill.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/bluegill.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:bluegill",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/boulti.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/boulti.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:boulti",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/box_turtle.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/box_turtle.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "aquaculture:box_turtle",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/brown_shrooma.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/brown_shrooma.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:brown_shrooma",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/brown_trout.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/brown_trout.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:brown_trout",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/capitaine.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/capitaine.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:capitaine",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/carp.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/carp.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:carp",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/catfish.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/catfish.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:catfish",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/gar.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/gar.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:gar",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/jellyfish.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/jellyfish.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:jellyfish",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/minnow.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/minnow.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:minnow",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/muskellunge.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/muskellunge.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:muskellunge",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/pacific_halibut.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/pacific_halibut.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:pacific_halibut",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/perch.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/perch.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:perch",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/pink_salmon.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/pink_salmon.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:pink_salmon",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/piranha.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/piranha.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:piranha",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/pollock.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/pollock.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:pollock",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/rainbow_trout.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/rainbow_trout.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:rainbow_trout",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/red_grouper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/red_grouper.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:red_grouper",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/red_shrooma.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/red_shrooma.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:red_shrooma",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/smallmouth_bass.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/smallmouth_bass.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:smallmouth_bass",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/starshell_turtle.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/starshell_turtle.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "aquaculture:starshell_turtle",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/synodontis.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/synodontis.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:synodontis",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/tambaqui.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/tambaqui.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:tambaqui",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/aquaculture/tuna.json
+++ b/src/main/resources/data/malum/spirit_data/entity/aquaculture/tuna.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "aquaculture:tuna",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/cactem.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/cactem.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:cactem",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/cindershell.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/cindershell.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:cindershell",
+  "primary_type": "infernal",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 2
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/end_whale.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/end_whale.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:end_whale",
+  "primary_type": "eldritch",
+  "spirits": [
+    {
+      "spirit": "eldritch",
+      "count": 2
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/lilytad.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/lilytad.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:lilytad",
+  "primary_type": "aqeuous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/little_grebe.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/little_grebe.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:little_grebe",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/lizard.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/lizard.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:lizard",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/minipad.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/minipad.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:minipad",
+  "primary_type": "aqeuous",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/sporeling.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/sporeling.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "cnb:sporeling",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/cnb/yeti.json
+++ b/src/main/resources/data/malum/spirit_data/entity/cnb/yeti.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "cnb:yeti",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 3
+    },
+    {
+      "spirit": "earthen",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/conjurer_illager/conjurer.json
+++ b/src/main/resources/data/malum/spirit_data/entity/conjurer_illager/conjurer.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "conjurer_illager:conjurer",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 3
+    },
+    {
+      "spirit": "arcane",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/badlands_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/badlands_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:badlands_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/bamboo_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/bamboo_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:bamboo_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/beach_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/beach_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:beach_creeper",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/cave_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/cave_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:cave_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/dark_oak_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/dark_oak_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:dark_oak_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/desert_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/desert_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:desert_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/dripstone_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/dripstone_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:dripstone_creeper",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/hills_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/hills_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:hills_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/jungle_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/jungle_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:jungle_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/mushroom_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/mushroom_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:mushroom_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/savannah_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/savannah_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:savannah_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/snowy_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/snowy_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:snowy_creeper",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/spruce_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/spruce_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:spruce_creeper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/swamp_creeper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/creeperoverhaul/swamp_creeper.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "creeperoverhaul:swamp_creeper",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/duckling/duck.json
+++ b/src/main/resources/data/malum/spirit_data/entity/duckling/duck.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "duckling:duck",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/duckling/quackling.json
+++ b/src/main/resources/data/malum/spirit_data/entity/duckling/quackling.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "duckling:quackling",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/guardvillagers/guard.json
+++ b/src/main/resources/data/malum/spirit_data/entity/guardvillagers/guard.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "guardvillagers:guard",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/hexerei/crow.json
+++ b/src/main/resources/data/malum/spirit_data/entity/hexerei/crow.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "hexerei:crow",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/humancompanions/arbalist.json
+++ b/src/main/resources/data/malum/spirit_data/entity/humancompanions/arbalist.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "humancompanions:arbalist",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/humancompanions/archer.json
+++ b/src/main/resources/data/malum/spirit_data/entity/humancompanions/archer.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "humancompanions:archer",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/humancompanions/knight.json
+++ b/src/main/resources/data/malum/spirit_data/entity/humancompanions/knight.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "humancompanions:knight",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "kobolds:kobold",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_captain.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_captain.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "kobolds:kobold_captain",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_child.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_child.json
@@ -1,5 +1,5 @@
 {
-  "registry_name": "kobolds:kobold",
+  "registry_name": "kobolds:kobold_child",
   "primary_type": "earthen",
   "spirits": [
     {

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_child.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_child.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "kobolds:kobold",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_enchanter.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_enchanter.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "kobolds:kobold_enchanter",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_engineer.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_engineer.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "kobolds:kobold_engineer",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_pirate.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_pirate.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "kobolds:kobold_pirate",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_skeleton.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_skeleton.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "kobolds:kobold_skeleton",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_warrior.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_warrior.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "kobolds:kobold_warrior",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_zombie.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_zombie.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "kobolds:kobold_zombie",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_zombie_drowned.json
+++ b/src/main/resources/data/malum/spirit_data/entity/kobolds/kobold_zombie_drowned.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "kobolds:kobold_zombie_drowned",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_marsh_tit.json
+++ b/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_marsh_tit.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "natural_decoration:little_marsh_tit",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_red_breasted_blackbird.json
+++ b/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_red_breasted_blackbird.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "natural_decoration:little_red_breasted_blackbird",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_robin.json
+++ b/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_robin.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "natural_decoration:little_robin",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_sparrow.json
+++ b/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_sparrow.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "natural_decoration:little_sparrow",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_swallow.json
+++ b/src/main/resources/data/malum/spirit_data/entity/natural_decoration/little_swallow.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "natural_decoration:little_swallow",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/natural_decoration/small_snails.json
+++ b/src/main/resources/data/malum/spirit_data/entity/natural_decoration/small_snails.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "natural_decoration:small_snails",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/sushigocrafting/shrimp.json
+++ b/src/main/resources/data/malum/spirit_data/entity/sushigocrafting/shrimp.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "sushigocrafting:shrimp",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/sushigocrafting/tuna.json
+++ b/src/main/resources/data/malum/spirit_data/entity/sushigocrafting/tuna.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "sushigocrafting:tuna",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/alpha_yeti.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/alpha_yeti.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:alpha_yeti",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 3
+    },
+    {
+      "spirit": "aqueous",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/armored_giant.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/armored_giant.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:armored_giant",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/bighorn_sheep.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/bighorn_sheep.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:bighorn_sheep",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/blockchain_goblin.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/blockchain_goblin.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:blockchain_goblin",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/boar.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/boar.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:boar",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_broodling.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_broodling.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:carminite_broodling",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_ghastguard.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_ghastguard.json
@@ -1,0 +1,22 @@
+{
+  "registry_name": "twilightforest:carminite_ghastguard",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 2
+    },
+    {
+      "spirit": "aqueous",
+      "count": 2
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_ghastling.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_ghastling.json
@@ -1,5 +1,5 @@
 {
-  "registry_name": "twilightforest:carminite_ghastguard",
+  "registry_name": "twilightforest:carminite_ghastling",
   "primary_type": "arcane",
   "spirits": [
     {

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_ghastling.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_ghastling.json
@@ -1,0 +1,22 @@
+{
+  "registry_name": "twilightforest:carminite_ghastguard",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_golem.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/carminite_golem.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:carminite_golem",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 3
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/death_tome.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/death_tome.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:death_tome",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/deer.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/deer.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:deer",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/dwarf_rabbit.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/dwarf_rabbit.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:dwarf_rabbit",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/fire_beetle.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/fire_beetle.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:fire_beetle",
+  "primary_type": "infernal",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "infernal",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/giant_miner.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/giant_miner.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:giant_miner",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/hedge_spider.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/hedge_spider.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:hedge_spider",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/helmet_crab.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/helmet_crab.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:helmet_crab",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/hostile_wolf.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/hostile_wolf.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:hostile_wolf",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/hydra.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/hydra.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:hydra",
+  "primary_type": "infernal",
+  "spirits": [
+    {
+      "spirit": "infernal",
+      "count": 3
+    },
+    {
+      "spirit": "wicked",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/king_spider.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/king_spider.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:king_spider",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 2
+    },
+    {
+      "spirit": "earthen",
+      "count": 4
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/knight_phantom.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/knight_phantom.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:knight_phantom",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 3
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/kobold.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/kobold.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:kobold",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/lich.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/lich.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:lich",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 3
+    },
+    {
+      "spirit": "wicked",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/lower_goblin_knight.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/lower_goblin_knight.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:lower_goblin_knight",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/maze_slime.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/maze_slime.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:maze_slime",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/minoshroom.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/minoshroom.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:minoshroom",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 3
+    },
+    {
+      "spirit": "wicked",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/minotaur.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/minotaur.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:minotaur",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/mist_wolf.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/mist_wolf.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:mist_wolf",
+  "primary_type": "eldritch",
+  "spirits": [
+    {
+      "spirit": "eldritch",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/mosquito_swarm.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/mosquito_swarm.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:mosquito_swarm",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/naga.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/naga.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "twilightforest:naga",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 3
+    },
+    {
+      "spirit": "arcane",
+      "count": 3
+    },
+    {
+      "spirit": "sacred",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/penguin.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/penguin.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:penguin",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/penguin.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/penguin.json
@@ -5,6 +5,10 @@
     {
       "spirit": "aqueous",
       "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
     }
   ]
 }

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/pinch_beetle.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/pinch_beetle.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:pinch_beetle",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/quest_ram.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/quest_ram.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:quest_ram",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 5
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/raven.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/raven.json
@@ -5,6 +5,10 @@
     {
       "spirit": "aerial",
       "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
     }
   ]
 }

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/raven.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/raven.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:raven",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/redcap.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/redcap.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:redcap",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/redcap_sapper.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/redcap_sapper.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:redcap_sapper",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/skeleton_druid.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/skeleton_druid.json
@@ -1,0 +1,18 @@
+{
+  "registry_name": "twilightforest:skeleton_druid",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 2
+    },
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/slime_beetle.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/slime_beetle.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:slime_beetle",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/snow_guardian.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/snow_guardian.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:snow_guardian",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/snow_queen.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/snow_queen.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:snow_queen",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 3
+    },
+    {
+      "spirit": "aerial",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/squirrel.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/squirrel.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:squirrel",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/stable_ice_core.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/stable_ice_core.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:stable_ice_core",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/swarm_spider.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/swarm_spider.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:swarm_spider",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/tiny_bird.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/tiny_bird.json
@@ -5,6 +5,10 @@
     {
       "spirit": "aerial",
       "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
     }
   ]
 }

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/tiny_bird.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/tiny_bird.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:tiny_bird",
+  "primary_type": "aerial",
+  "spirits": [
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/towerwood_borer.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/towerwood_borer.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:towerwood_borer",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/troll.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/troll.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:troll",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/unstable_ice_core.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/unstable_ice_core.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:unstable_ice_core",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 1
+    },
+    {
+      "spirit": "aerial",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/upper_goblin_knight.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/upper_goblin_knight.json
@@ -1,0 +1,10 @@
+{
+  "registry_name": "twilightforest:upper_goblin_knight",
+  "primary_type": "earthen",
+  "spirits": [
+    {
+      "spirit": "earthen",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/ur_ghast.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/ur_ghast.json
@@ -1,0 +1,22 @@
+{
+  "registry_name": "twilightforest:ur_ghast",
+  "primary_type": "arcane",
+  "spirits": [
+    {
+      "spirit": "arcane",
+      "count": 3
+    },
+    {
+      "spirit": "infernal",
+      "count": 3
+    },
+    {
+      "spirit": "aqueous",
+      "count": 3
+    },
+    {
+      "spirit": "aerial",
+      "count": 3
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/winter_wolf.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/winter_wolf.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:winter_wolf",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 2
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/wraith.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/wraith.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:wraith",
+  "primary_type": "wicked",
+  "spirits": [
+    {
+      "spirit": "wicked",
+      "count": 2
+    },
+    {
+      "spirit": "eldritch",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/twilightforest/yeti.json
+++ b/src/main/resources/data/malum/spirit_data/entity/twilightforest/yeti.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "twilightforest:yeti",
+  "primary_type": "sacred",
+  "spirits": [
+    {
+      "spirit": "sacred",
+      "count": 1
+    },
+    {
+      "spirit": "aqueous",
+      "count": 1
+    }
+  ]
+}

--- a/src/main/resources/data/malum/spirit_data/entity/waddles/adelie_penguin.json
+++ b/src/main/resources/data/malum/spirit_data/entity/waddles/adelie_penguin.json
@@ -1,0 +1,14 @@
+{
+  "registry_name": "waddles:adelie_penguin",
+  "primary_type": "aqueous",
+  "spirits": [
+    {
+      "spirit": "aqueous",
+      "count": 1
+    },
+    {
+      "spirit": "sacred",
+      "count": 1
+    }
+  ]
+}


### PR DESCRIPTION
Additional spirits!

- Copied the Twilight Forest spirits from the 1.18.1 branch over to 1.18.2
- Added sacred to Twilight Forest penguins, ravens

Adds spirits for the following mods:

- Human Companions
- Guard Villagers
- Kobolds
- Waddles
- Sushi Go Crafting
- Natural Decoration
- Duckling
- Creeper Overhaul
- The Conjurer
- Creatures & Beasts
- Aquaculture