### PR TITLE
[Fabric] Fix Trinkets tooltip translation keys

### DIFF
--- a/src/generated/resources/assets/malum/lang/en_us.json
+++ b/src/generated/resources/assets/malum/lang/en_us.json
@@ -1660,8 +1660,7 @@
   "tetra.material.tainted_rock.prefix": "Tainted Rock",
   "tetra.material.twisted_rock": "Twisted Rock",
   "tetra.material.twisted_rock.prefix": "Twisted Rock",
-  "trinket.identifier.brooch": "Brooch",
-  "trinket.identifier.rune": "Rune",
-  "trinket.modifiers.brooch": "When worn:",
-  "trinket.modifiers.rune": "When equipped:"
+  "trinkets.slot.chest.brooch": "Brooch",
+  "trinkets.slot.head.charm": "Charm",
+  "trinkets.slot.legs.rune": "Rune"
 }

--- a/src/main/java/com/sammy/malum/data/MalumLang.java
+++ b/src/main/java/com/sammy/malum/data/MalumLang.java
@@ -169,11 +169,14 @@ public class MalumLang extends LanguageProvider {
         }
 
 
-        add("trinket.identifier.brooch", "Brooch");
-        add("trinket.modifiers.brooch", "When worn:");
+        add("trinkets.slot.chest.brooch", "Brooch");
+        //add("trinket.modifiers.brooch", "When worn:");
 
-        add("trinket.identifier.rune", "Rune");
-        add("trinket.modifiers.rune", "When equipped:");
+        add("trinkets.slot.head.charm", "Charm");
+        //add("trinket.modifiers.charm", "When equipped:");
+
+        add("trinkets.slot.legs.rune", "Rune");
+        //add("trinket.modifiers.rune", "When equipped:");
 
         add("malum.gui.trinket.positive", "+%s");
         add("malum.gui.trinket.negative", "-%s");


### PR DESCRIPTION
This PR corrects the translation keys for the three non-default trinket slots Malum adds. They will now be translated correctly in-game.

Trinkets does not appear to have an equivalent translation key system for `"curios.modifiers.<slot>"`, et al., so those have been commented out.