### PR TITLE
[Fabric] CurioElaborateBrooch: use correct ID for necklace trinket slot 

### DIFF
--- a/src/main/java/com/sammy/malum/common/item/curiosities/trinkets/brooches/CurioElaborateBrooch.java
+++ b/src/main/java/com/sammy/malum/common/item/curiosities/trinkets/brooches/CurioElaborateBrooch.java
@@ -23,6 +23,6 @@ public class CurioElaborateBrooch extends MalumTinketsItem {
     @Override
     public void addAttributeModifiers(Multimap<Attribute, AttributeModifier> map, SlotReference slotContext, ItemStack stack, LivingEntity entity) {
         SlotAttributes.addSlotModifier(map, "legs/belt", ELABORATE_BROOCH_BELT, 1, AttributeModifier.Operation.ADDITION);
-        SlotAttributes.addSlotModifier(map, "head/necklace", ELABORATE_BROOCH_NECKLACE, -1, AttributeModifier.Operation.ADDITION);
+        SlotAttributes.addSlotModifier(map, "chest/necklace", ELABORATE_BROOCH_NECKLACE, -1, AttributeModifier.Operation.ADDITION);
     }
 }


### PR DESCRIPTION
As seen on the [Default Slots](https://github.com/emilyploszaj/trinkets/wiki/Default-Slots) page of the Trinkets wiki, the correct ID for the "necklace" trinket slot is `chest/necklace`, not `head/necklace`.

(apologies in advance to whoever was using this oversight to their advantage)