### PR TITLE
Preservation Turrets have no soul to be shattered

### DIFF
--- a/src/main/resources/data/malum/spirit_data/entity/spectrum/preservation_turret.json
+++ b/src/main/resources/data/malum/spirit_data/entity/spectrum/preservation_turret.json
@@ -1,14 +1,3 @@
 {
-  "registry_name": "spectrum:preservation_turrets",
-  "primary_type": "earthen",
-  "spirits": [
-    {
-      "spirit": "earthen",
-      "count": 4
-    },
-    {
-      "spirit": "arcane",
-      "count": 1
-    }
-  ]
+  "registry_name": "spectrum:preservation_turrets"
 }


### PR DESCRIPTION
Not sure if I did this right as there was no armor_stand.json to use as an example

Preservation Turrets do not have a soul. They are purely mechanical constructs, and are straight up in spectrum's #soulless tag (alongside armor stands, everyone's favorite LivingEntity).

It doesn't make sense to get any spirit crystals here, as there is _no soul to be shattered_.