### PR TITLE
fix rite of culling

### DIFF
--- a/src/main/java/com/sammy/malum/common/spiritrite/eldritch/EldritchWickedRiteType.java
+++ b/src/main/java/com/sammy/malum/common/spiritrite/eldritch/EldritchWickedRiteType.java
@@ -47,7 +47,7 @@ public class EldritchWickedRiteType extends TotemicRiteType {
             public void doRiteEffect(TotemBaseBlockEntity totemBase, ServerLevel level) {
                 DamageSource damageSource = DamageTypeHelper.create(level, MalumDamageTypes.VOODOO_PLAYERLESS);
                 Map<Class<? extends Animal>, List<Animal>> animalMap = getNearbyEntities(totemBase, Animal.class,
-                        e -> e.getAge() > 0 && !e.isInvulnerableTo(damageSource)).collect(Collectors.groupingBy(Animal::getClass));
+                        e -> e.getAge() >= 0 && !e.isInvulnerableTo(damageSource)).collect(Collectors.groupingBy(Animal::getClass));
                 for (List<Animal> animals : animalMap.values()) {
                     if (animals.size() < 20) {
                         continue;


### PR DESCRIPTION
Attempt to fix rite of culling
Tested in singleplayer

According to the Minecraft wiki, the age value for mobs:
Represents the age of the mob in ticks; when negative, the mob is a baby. When 0 or above, the mob is an adult. When above 0, represents the number of ticks before this mob can breed again.
The current code checks instead for mobs that have **strictly** more than 0 age