### PR TITLE
WorldGen: Make tree and ore generation fully deterministic

### DIFF
--- a/src/main/java/com/sammy/malum/common/worldgen/WorldgenHelper.java
+++ b/src/main/java/com/sammy/malum/common/worldgen/WorldgenHelper.java
@@ -3,12 +3,18 @@ package com.sammy.malum.common.worldgen;
 import com.google.common.collect.*;
 import com.sammy.malum.common.block.nature.*;
 import net.minecraft.core.*;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.*;
 import net.minecraft.world.level.block.state.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class WorldgenHelper {
+
+    public static <T> List<T> shuffle(Collection<T> collection, RandomSource random) {
+        return collection.stream().sorted((a, b) -> random.nextIntBetweenInclusive(-1, 0)).toList();
+    }
 
     public static void updateLeaves(LevelAccessor pLevel, Collection<BlockPos> logPositions) {
         List<Set<BlockPos>> list = Lists.newArrayList();

--- a/src/main/java/com/sammy/malum/common/worldgen/blight/BlightFeature.java
+++ b/src/main/java/com/sammy/malum/common/worldgen/blight/BlightFeature.java
@@ -1,6 +1,7 @@
 package com.sammy.malum.common.worldgen.blight;
 
 import com.google.common.collect.*;
+import com.sammy.malum.common.worldgen.WorldgenHelper;
 import com.sammy.malum.registry.common.*;
 import com.sammy.malum.registry.common.block.*;
 import com.sammy.malum.visual_effects.networked.blight.*;
@@ -105,9 +106,8 @@ public class BlightFeature extends Feature<NoneFeatureConfiguration> {
             }
         }
 
-        ArrayList<BlockPos> floraPositions = new ArrayList<>(blightedArea);
-        if (!floraPositions.isEmpty()) {
-            Collections.shuffle(floraPositions);
+        if (!blightedArea.isEmpty()) {
+            List<BlockPos> floraPositions = WorldgenHelper.shuffle(blightedArea, random);
             int floraCount = Math.min(random.nextInt(1, radius * 4 + 1), floraPositions.size() - 1);
             boolean hasSoulwood = false;
             for (BlockPos blockPos : floraPositions) {
@@ -138,9 +138,8 @@ public class BlightFeature extends Feature<NoneFeatureConfiguration> {
                 }
             }
         }
-        List<BlockPos> coveringArea = fetchCoveringPositions(level, pos, radius + 3);
+        List<BlockPos> coveringArea = WorldgenHelper.shuffle(fetchCoveringPositions(level, pos, radius + 3), random);
         if (!coveringArea.isEmpty()) {
-            Collections.shuffle(coveringArea);
             int coveringCount = Math.min(random.nextInt(1, 8 + radius * 8 + 1), coveringArea.size() - 1);
             for (BlockPos blockPos : coveringArea) {
                 BlockState state = level.getBlockState(blockPos);

--- a/src/main/java/com/sammy/malum/common/worldgen/blight/ScarstoneFeature.java
+++ b/src/main/java/com/sammy/malum/common/worldgen/blight/ScarstoneFeature.java
@@ -2,6 +2,7 @@ package com.sammy.malum.common.worldgen.blight;
 
 import com.google.common.collect.*;
 import com.sammy.malum.common.block.blight.scarstone.*;
+import com.sammy.malum.common.worldgen.WorldgenHelper;
 import com.sammy.malum.registry.common.*;
 import com.sammy.malum.registry.common.block.*;
 import net.minecraft.core.*;
@@ -51,9 +52,8 @@ public class ScarstoneFeature extends Feature<NoneFeatureConfiguration> {
             }
         }
 
-        List<BlockPos> crystalPositions = fetchCoveringPositions(level, pos, radius-1);
+        List<BlockPos> crystalPositions = WorldgenHelper.shuffle(fetchCoveringPositions(level, pos, radius-1), random);
         if (!crystalPositions.isEmpty()) {
-            Collections.shuffle(crystalPositions);
             int floraCount = Math.min(random.nextInt(radius * 2 + 1, radius * 4 + 1), crystalPositions.size() - 1);
             for (BlockPos blockPos : crystalPositions) {
                 BlockPos above = blockPos.above();

--- a/src/main/java/com/sammy/malum/common/worldgen/ore/CthonicGoldOreFeature.java
+++ b/src/main/java/com/sammy/malum/common/worldgen/ore/CthonicGoldOreFeature.java
@@ -1,5 +1,6 @@
 package com.sammy.malum.common.worldgen.ore;
 
+import com.sammy.malum.common.worldgen.WorldgenHelper;
 import com.sammy.malum.registry.common.block.*;
 import net.minecraft.core.*;
 import net.minecraft.util.*;
@@ -149,11 +150,11 @@ public class CthonicGoldOreFeature extends LayeredOreFeature{
 
     public void placeClusters(List<Runnable> clusterPlacements, RandomSource random) {
         if (!clusterPlacements.isEmpty()) {
-            Collections.shuffle(clusterPlacements);
-            int clusterAmount = (clusterPlacements.size() + random.nextInt(4)) / 3;
+            List<Runnable> shuffledClusterPlacements = WorldgenHelper.shuffle(clusterPlacements, random);
+            int clusterAmount = (shuffledClusterPlacements.size() + random.nextInt(4)) / 3;
             if (clusterAmount != 0) {
-                for (int k = 0; k < Math.min(clusterAmount, clusterPlacements.size()); k++) {
-                    clusterPlacements.get(k).run();
+                for (int k = 0; k < Math.min(clusterAmount, shuffledClusterPlacements.size()); k++) {
+                    shuffledClusterPlacements.get(k).run();
                 }
             }
         }

--- a/src/main/java/com/sammy/malum/common/worldgen/tree/RunewoodTreeFeature.java
+++ b/src/main/java/com/sammy/malum/common/worldgen/tree/RunewoodTreeFeature.java
@@ -2,6 +2,7 @@ package com.sammy.malum.common.worldgen.tree;
 
 import com.sammy.malum.common.block.blight.*;
 import com.sammy.malum.common.block.nature.*;
+import com.sammy.malum.common.worldgen.WorldgenHelper;
 import com.sammy.malum.registry.common.block.*;
 import net.minecraft.core.*;
 import net.minecraft.tags.*;
@@ -120,8 +121,7 @@ public class RunewoodTreeFeature extends Feature<RunewoodTreeConfiguration> {
         }
         makeLeafBlob(config, filler, mutable.set(pos).move(Direction.UP, trunkHeight-1));
 
-        ArrayList<BlockPos> sapBlockPositions = new ArrayList<>(filler.getLayer(LOGS).keySet());
-        Collections.shuffle(sapBlockPositions);
+        List<BlockPos> sapBlockPositions = WorldgenHelper.shuffle(filler.getLayer(LOGS).keySet(), rand);
         for (BlockPos blockPos : sapBlockPositions.subList(0, sapBlockCount)) {
             filler.getLayer(LOGS).replace(blockPos, e -> create(BlockStateHelper.getBlockStateWithExistingProperties(e.getState(), MalumBlocks.EXPOSED_RUNEWOOD_LOG.get().defaultBlockState())).build());
         }

--- a/src/main/java/com/sammy/malum/common/worldgen/tree/SoulwoodTreeFeature.java
+++ b/src/main/java/com/sammy/malum/common/worldgen/tree/SoulwoodTreeFeature.java
@@ -3,6 +3,7 @@ package com.sammy.malum.common.worldgen.tree;
 import com.sammy.malum.common.block.blight.*;
 import com.sammy.malum.common.block.blight.CreepingBlightBlock.*;
 import com.sammy.malum.common.block.nature.*;
+import com.sammy.malum.common.worldgen.WorldgenHelper;
 import com.sammy.malum.common.worldgen.blight.*;
 import com.sammy.malum.registry.common.block.*;
 import net.minecraft.core.*;
@@ -16,6 +17,10 @@ import net.minecraft.world.level.levelgen.feature.configurations.*;
 import team.lodestar.lodestone.helpers.*;
 import team.lodestar.lodestone.systems.worldgen.*;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.*;
 
 import static com.sammy.malum.common.block.blight.CreepingBlightBlock.BlightType.*;
@@ -203,7 +208,7 @@ public class SoulwoodTreeFeature extends Feature<NoneFeatureConfiguration> {
             makeLeafBlob(leavesLayer, rand, mutable.move(Direction.DOWN, branchHeight-1));
         }
 
-        for (LodestoneWorldgenBuilderEntry entry : treeLayer.getRandomEntries(getSapBlockCount(rand))) {
+        for (LodestoneWorldgenBuilderEntry entry : getRandomEntries(treeLayer.getOrderedEntries(), getSapBlockCount(rand), rand)) {
             entry.changeState(s -> {
                 if (s.getBlock().equals(MalumBlocks.SOULWOOD_LOG.get())) {
                     return MalumBlocks.EXPOSED_SOULWOOD_LOG.get().defaultBlockState().setValue(RotatedPillarBlock.AXIS, s.getValue(RotatedPillarBlock.AXIS));
@@ -211,7 +216,7 @@ public class SoulwoodTreeFeature extends Feature<NoneFeatureConfiguration> {
                 return s;
             });
         }
-        for (LodestoneWorldgenBuilderEntry entry : treeLayer.getRandomEntries(getSpikeCount(rand))) {
+        for (LodestoneWorldgenBuilderEntry entry : getRandomEntries(treeLayer.getOrderedEntries(), getSpikeCount(rand), rand)) {
             if (entry.position().getY() > pos.getY()+3) {
                 entry.addAdditionalPlacement(((l, e) -> {
                     Direction direction = Direction.from2DDataValue(l.getRandom().nextInt(4));
@@ -227,6 +232,12 @@ public class SoulwoodTreeFeature extends Feature<NoneFeatureConfiguration> {
         updateLeaves(level, treeLayer.getAffectedArea());
         return true;
     }
+
+	private static <T> ArrayList<T> getRandomEntries(Collection<T> collection, int amount, RandomSource rand) {
+		return new ArrayList<>(
+			WorldgenHelper.shuffle(collection, rand).subList(0, Math.min(amount, collection.size()))
+		);
+	}
 
     public BlockPos addDownwardsTrunkConnections(WorldGenLevel level, BlockPos pos, Consumer<BlockPos> consumer) {
         var mutable = pos.mutable();


### PR DESCRIPTION
There were a few `Collections.shuffle()` calls used to generate some of the randomness for world generation. Sadly, this does not respect the `RandomSource` used by Minecraft.

This PR adds a new WorldgenHelper that shuffles Collections by using a given RandomSource and then uses it for tree and ore generation. This ensures that the same world seeds generate the same ore veins and trees.