### PR TITLE
Update botania and undergarden spirit repairs

### DIFF
--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/alfsteel.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/alfsteel.json
@@ -6,8 +6,6 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "alfsteel_.+",
-  "modIdRegex": "mythicbotany",
   "durabilityPercentage": 1,
   "inputs": [
   ],
@@ -20,5 +18,9 @@
       "type": "arcane",
       "count": 64
     }
-  ]
+  ],
+  "regex": {
+    "itemIdRegex": "alfsteel_.+",
+    "modIdRegex": "mythicbotany"
+  }
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/elementium.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/elementium.json
@@ -6,13 +6,7 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "elementium_.+",
-  "modIdRegex": "botania",
   "durabilityPercentage": 1,
-  "inputs": [
-    "botania:star_sword",
-    "botania:thunder_sword"
-  ],
   "repairMaterial": {
     "item": "botania:elementium_ingot",
     "count": 1
@@ -22,5 +16,13 @@
       "type": "arcane",
       "count": 24
     }
+  ],
+  "regex": {
+    "itemIdRegex": "elementium_.+",
+    "modIdRegex": "botania"
+  },
+  "validItems": [
+    "botania:elementium_sword",
+    "botania:thunder_sword"
   ]
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/manasteel.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/manasteel.json
@@ -6,12 +6,7 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "manasteel_.+",
-  "modIdRegex": "botania",
   "durabilityPercentage": 1,
-  "inputs": [
-    "botania:ender_dagger"
-  ],
   "repairMaterial": {
     "item": "botania:manasteel_ingot",
     "count": 2
@@ -21,5 +16,12 @@
       "type": "arcane",
       "count": 16
     }
+  ],
+  "regex": {
+    "itemIdRegex": "manasteel_.+",
+    "modIdRegex": "botania"
+  },
+  "validItems": [
+    "botania:ender_dagger"
   ]
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/terrasteel.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/botania/terrasteel.json
@@ -6,10 +6,7 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "terra.+",
-  "modIdRegex": "botania",
   "durabilityPercentage": 1,
-  "inputs": [],
   "repairMaterial": {
     "item": "botania:terrasteel_ingot",
     "count": 1
@@ -19,5 +16,9 @@
       "type": "arcane",
       "count": 32
     }
-  ]
+  ],
+  "regex": {
+    "itemIdRegex": "terra.+",
+    "modIdRegex": "botania"
+  }
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/cloggrum.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/cloggrum.json
@@ -6,10 +6,7 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "cloggrum_.+",
-  "modIdRegex": "undergarden",
   "durabilityPercentage": 0.5,
-  "inputs": [],
   "repairMaterial": {
     "item": "undergarden:cloggrum_ingot",
     "count": 2
@@ -19,5 +16,9 @@
       "type": "earthen",
       "count": 12
     }
-  ]
+  ],
+  "regex": {
+    "itemIdRegex": "cloggrum_.+",
+    "modIdRegex": "undergarden"
+  }
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/forgotten.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/forgotten.json
@@ -27,5 +27,6 @@
       "type": "eldritch",
       "count": 2
     }
-  ]
+  ],
+  "regex": {}
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/froststeel.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/froststeel.json
@@ -6,10 +6,7 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "froststeel_.+",
-  "modIdRegex": "undergarden",
   "durabilityPercentage": 0.5,
-  "inputs": [],
   "repairMaterial": {
     "item": "undergarden:froststeel_ingot",
     "count": 2
@@ -23,5 +20,9 @@
       "type": "arcane",
       "count": 4
     }
-  ]
+  ],
+  "regex": {
+    "itemIdRegex": "froststeel_.+",
+    "modIdRegex": "undergarden"
+  }
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/slingshot.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/slingshot.json
@@ -6,12 +6,7 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "",
-  "modIdRegex": "",
   "durabilityPercentage": 0.5,
-  "inputs": [
-    "undergarden:slingshot"
-	],
   "repairMaterial": {
     "item": "undergarden:twistytwig",
     "count": 1
@@ -21,5 +16,8 @@
       "type": "earthen",
       "count": 2
     }
+  ],
+  "validItems": [
+    "undergarden:slingshot"
   ]
 }

--- a/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/utherium.json
+++ b/src/main/resources/data/malum/recipe/malum/spirit_repair/undergarden/utherium.json
@@ -6,8 +6,6 @@
     }
   ],
   "type": "malum:spirit_repair",
-  "itemIdRegex": "utherium_.+",
-  "modIdRegex": "undergarden",
   "durabilityPercentage": 0.5,
   "inputs": [],
   "repairMaterial": {
@@ -23,5 +21,9 @@
       "type": "infernal",
       "count": 12
     }
-  ]
+  ],
+  "regex": {
+    "itemIdRegex": "utherium_.+",
+    "modIdRegex": "undergarden"
+  }
 }


### PR DESCRIPTION
Update undergarden and botania spirit repair integration. Untested, but, supposedly, works.