### PR TITLE
Fix infinite config correction loop for scarfOpacity

### DIFF
--- a/src/main/java/com/sammy/malum/config/ClientConfig.java
+++ b/src/main/java/com/sammy/malum/config/ClientConfig.java
@@ -28,9 +28,9 @@ public class ClientConfig extends LodestoneConfig {
     public static ConfigValueHolder<Integer> SCARF_LENGTH = new ConfigValueHolder<>(MALUM, "client/scarf", (builder ->
             builder.comment("How long should the Malignant Stronghold Scarf be? This value will affect all rendered scarves, not just the one worn by the local player.")
                     .define("scarfLength", 30)));
-    public static ConfigValueHolder<Float> SCARF_OPACITY = new ConfigValueHolder<>(MALUM, "client/scarf", (builder ->
-            builder.comment("How visible. should the Malignant Stronghold Scarf be in first person?")
-                    .define("scarfOpacity", 0.4f)));
+    public static ConfigValueHolder<Double> SCARF_OPACITY = new ConfigValueHolder<>(MALUM, "client/scarf", (builder ->
+            builder.comment("How visible should the Malignant Stronghold Scarf be in first person?")
+                    .define("scarfOpacity", 0.4d)));
 
     public static ConfigValueHolder<Boolean> PARALLEL_WORLD = new ConfigValueHolder<>(MALUM, "client/renderpass", (builder ->
             builder.comment("Enable or disable the parallel world renderer, used for various effects related to a certain feature. Disable if it causes framerate issues.")


### PR DESCRIPTION
## Summary
- Fix infinite `malum-client.toml is not correct. Correcting` loop that fires every 2 seconds
- Root cause: `scarfOpacity` defined as `Float` (0.4f) but TOML always parses floating-point as `Double` — NeoForge's config validator sees the type mismatch and rewrites endlessly
- Changed `ConfigValueHolder<Float>` to `ConfigValueHolder<Double>` and `0.4f` to `0.4d`
- Also fixed typo in comment: "How visible." → "How visible"

## Test plan
- [ ] Launch client, check that `malum-client.toml is not correct. Correcting` no longer appears in logs
- [ ] Verify scarf opacity still works in first person

🤖 Generated with [Claude Code](https://claude.com/claude-code)