### PR TITLE
Fix scarf opacity config type handling

### DIFF
--- a/src/main/java/com/sammy/malum/client/scarf/ScarfRenderHandler.java
+++ b/src/main/java/com/sammy/malum/client/scarf/ScarfRenderHandler.java
@@ -134,7 +134,7 @@ public class ScarfRenderHandler {
             float alpha = this.alpha;
             if (entity.equals(minecraft.cameraEntity)) {
                 if (minecraft.options.getCameraType().isFirstPerson()) {
-                    alpha *= ClientConfig.SCARF_OPACITY.getConfigValue();
+                    alpha *= ClientConfig.SCARF_OPACITY.getConfigValue().floatValue();
                 }
             }
             if (alpha <= 0) {

--- a/src/main/java/com/sammy/malum/config/ClientConfig.java
+++ b/src/main/java/com/sammy/malum/config/ClientConfig.java
@@ -30,7 +30,7 @@ public class ClientConfig extends LodestoneConfig {
                     .define("scarfLength", 30)));
     public static ConfigValueHolder<Double> SCARF_OPACITY = new ConfigValueHolder<>(MALUM, "client/scarf", (builder ->
             builder.comment("How visible. should the Malignant Stronghold Scarf be in first person?")
-                    .define("scarfOpacity", 0.4)));
+                    .define("scarfOpacity", 0.4D)));
 
     public static ConfigValueHolder<Boolean> PARALLEL_WORLD = new ConfigValueHolder<>(MALUM, "client/renderpass", (builder ->
             builder.comment("Enable or disable the parallel world renderer, used for various effects related to a certain feature. Disable if it causes framerate issues.")


### PR DESCRIPTION
Fixes a repeated client config correction warning for `scarfOpacity`.

NeoForge was repeatedly reporting that the Malum client config was not correct and rewriting it, when it was launching:

```text
[net.neoforged.neoforge.common.ModConfigSpec/CORE]: Incorrect key scarfOpacity was corrected from 0.4 to 0.4
[net.neoforged.neoforge.common.ModConfigTracker/CORE]: The configuration file malum-client.toml is not correct. Correcting
```

`SCARF_OPACITY` is currently a `Double` config value, but a couple spots were still relying on implicit numeric handling. This changes the default to `0.4D` and converts the value to a float at the render site where it is multiplied into `alpha`.

Let me know if I missed anything important in the guidelines for making a PR :)