### PR TITLE
Fix witchhazel crop max age to prevent invalid age-7 states

### DIFF
--- a/src/main/java/com/sammy/malum/common/block/flora/WitchhazelCropBlock.java
+++ b/src/main/java/com/sammy/malum/common/block/flora/WitchhazelCropBlock.java
@@ -40,6 +40,11 @@ public class WitchhazelCropBlock extends CropBlock {
     }
 
     @Override
+    public int getMaxAge() {
+        return 6;
+    }
+
+    @Override
     protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return SHAPE_BY_AGE[this.getAge(state)];
     }


### PR DESCRIPTION
I came across a startup crash when Malum is loaded with quark. Looks like it is inspecting crop maturity through `CropBlock#getMaxAge()`.

`WitchhazelCropBlock` looks to have the age property as `0..6`, but inherited the vanilla `CropBlock#getMaxAge()` value of `7`. Some mods (like Quark's "Simple Harvest") can call `getStateForAge(getMaxAge())`, which tries to create an invalid `age=7` state for `malum:witchhazel`.

This patch overrides `getMaxAge()` to return `6`, matching `AGE_6`.

```text
java.lang.IllegalArgumentException: Cannot set property IntegerProperty{name=age, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6]} to 7 on Block{malum:witchhazel}, it is not an allowed value
    at net.minecraft.world.level.block.CropBlock.getStateForAge(CropBlock.java:73)
    at org.violetmoon.quark.content.tweaks.module.SimpleHarvestModule.configChanged(SimpleHarvestModule.java:128)
```