### PR TITLE
Register item handler capability for spirit jar block

### DIFF
--- a/src/main/java/com/sammy/malum/common/data/component/SpiritJarContentsComponent.java
+++ b/src/main/java/com/sammy/malum/common/data/component/SpiritJarContentsComponent.java
@@ -21,7 +21,7 @@ public record SpiritJarContentsComponent(SpiritArcanaType spirit, int count) imp
     }
 
     public ItemStack createStack() {
-        return createStack(Math.min(count, 64));
+        return createStack(count);
     }
 
     public ItemStack createStack(int count) {

--- a/src/main/java/com/sammy/malum/registry/common/block/MalumBlockEntities.java
+++ b/src/main/java/com/sammy/malum/registry/common/block/MalumBlockEntities.java
@@ -136,6 +136,7 @@ public class MalumBlockEntities {
 
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
         event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, SPIRIT_ALTAR.get(), IInventoryCapabilityProvider::getInventory);
+        event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, SPIRIT_JAR.get(), IInventoryCapabilityProvider::getInventory);
         event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, ARCANA_PYLON.get(), IInventoryCapabilityProvider::getInventory);
         event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, SPIRIT_CRUCIBLE.get(), IInventoryCapabilityProvider::getInventory);
         event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, SPIRIT_CATALYZER.get(), IInventoryCapabilityProvider::getInventory);


### PR DESCRIPTION
Registering the capability allows for automatic item insertion via hoppers and similar things.

As a nice plus, this makes mods like Jade automatically support contents in the jar without needing explicit support. This was the main reason I created this PR, because many of the spirits have such similar colors it's hard to tell them apart with just the color. Also, it lets you see how many spirits are in a jar, which otherwise cannot be seen.
<img width="633" height="208" alt="image" src="https://github.com/user-attachments/assets/37d7bd0b-2372-4906-b1f2-1a1c1f6c85b6" />
