### PR TITLE
Fix ether item stacking inconsistencies

### DIFF
--- a/src/main/java/com/sammy/malum/common/item/ether/EtherItem.java
+++ b/src/main/java/com/sammy/malum/common/item/ether/EtherItem.java
@@ -36,7 +36,9 @@ public class EtherItem extends BlockItem implements ParticleEmitterHandler.ItemP
     }
 
     public EtherItem(Block block, Properties properties, boolean isIridescent) {
-        super(block, properties);
+        super(block, properties
+                .component(DataComponents.DYED_COLOR, DEFAULT_FIRST_COLOR)
+                .component(MalumDataComponents.SECONDARY_DYED_COLOR, DEFAULT_SECOND_COLOR));
         this.isIridescent = isIridescent;
     }
 


### PR DESCRIPTION
When crafting ether, placing one down and breaking it, it will no longer stack with ether items that have not been placed before. This is because of the secondary dyed color component not being included until it is dropped by the block. Adding the component values as defaults makes it so the items have the secondary dyed color component by default and thus will stack as intended.

This should also resolve stacking issues without needing to place and break existing ether items in a world.