### PR TITLE
Fix rite of rending culling.

### DIFF
--- a/src/main/java/com/sammy/malum/common/spiritrite/effect/wicked/MonsterRaisingEffect.java
+++ b/src/main/java/com/sammy/malum/common/spiritrite/effect/wicked/MonsterRaisingEffect.java
@@ -35,6 +35,6 @@ public class MonsterRaisingEffect extends SpiritRiteEntityEffect<Monster> {
         if (target.isInvulnerableTo(damageSource)) {
             return false;
         }
-        return target.getHealth() < target.getMaxHealth() * 0.1f;
+        return target.getHealth() <= Math.max( target.getMaxHealth() * 0.1f, 2.5f );
     }
 }


### PR DESCRIPTION
Rite of rending will now kill monsters either at or below 10% of their max health, or at 2.5 health.

Fixes https://github.com/SammySemicolon/Malum-Mod/issues/474